### PR TITLE
Fix cards home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ flask run
 - [x] Dual Code Blocks -> Added and fixed, removed most js and turned it into the html parser
 - [x] Codeblocks showing languages twice -> fixed by fix above
 - [x] Copy Button in Codeblock
+- [x] Fix Cards on Home Page
 
 ## Features/Issues to Update/Implement
 - [ ] Implement New Basic Web Analytics Cookies
-- [ ] Fix Cards on Home Page
 - [ ] {{< katex }} does not display correctly (Calculate Sample Sizes for web scrapers)
 - [ ] Presentation slides are not available (Blog - Introducing TSH at the Open to Complexity Symposium)
  

--- a/app.py
+++ b/app.py
@@ -188,7 +188,7 @@ def contribute():
     data_object = {'title' : 'Contribute to TSH'}
     meta_data = fetch_meta_data(data_object)
 
-    return redirect('/tutorials/more-tutorials/contribute-to-tilburg-science-hub/contribute')
+    return redirect('topics/collaborate-share/project-management/engage-open-science/contribute-to-tilburg-science-hub/contribute/')
 
 # Contribute
 @app.route('/search')

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -585,14 +585,7 @@ $(document).ready(function () {
     fetch('static/json/cards.json')
       .then(response => response.json())
       .then(data => {
-        if(data){
-          console.log("Data!!!!", data)
-          console.log("Tutorials ? -> ", data.tutorials)
-        } else {
-          console.log('Data is empty', data)
-        }
-        console.log("Current URL -> ", document.URL)
-        console.log("Yeah I think error is here")
+
         // Building Blocks
         const building_blocks = data.building_blocks || [];
         const ulElementBlock = document.getElementById('most-read-topics-list');

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -585,7 +585,14 @@ $(document).ready(function () {
     fetch('static/json/cards.json')
       .then(response => response.json())
       .then(data => {
-
+        if(data){
+          console.log("Data!!!!", data)
+          console.log("Tutorials ? -> ", data.tutorials)
+        } else {
+          console.log('Data is empty', data)
+        }
+        console.log("Current URL -> ", document.URL)
+        console.log("Yeah I think error is here")
         // Building Blocks
         const building_blocks = data.building_blocks || [];
         const ulElementBlock = document.getElementById('most-read-topics-list');
@@ -637,7 +644,7 @@ $(document).ready(function () {
         });
 
         // Tutorials
-        const tutorials = data.tutorials || [];
+        const tutorials = data.topics || [];
         const ulElementTutorial = document.getElementById('most-read-tutorials-list');
 
         // Select a random tutorial

--- a/static/json/cards.json
+++ b/static/json/cards.json
@@ -1,1 +1,86 @@
-{"tutorials": [{"path": "/tutorials/more-tutorials/chatgpt-article/chat-gpt-research/", "title": "Use ChatGPT for your research!", "description": "Currently, ChatGPT is everywhere. Learn how to use it efficiently to improve your research."}, {"path": "/tutorials/reproducible-research-and-automation/principles-of-project-setup-and-workflow-management/project-setup-overview/", "title": "Principles of Project Setup and Workflow Management", "description": "When working on a project, most of us spend time thinking about what to create (a cleaned data set, a new algorithm, an analysis, a paper and corresponding slides), but not about how to manage its creation."}, {"path": "/tutorials/more-tutorials/contribute-to-tilburg-science-hub/contribute/", "title": "Contribute to Tilburg Science Hub", "description": "Learn how to contribute to Tilburg Science Hub in three easy ways."}, {"path": "/tutorials/reproducible-research-and-automation/principles-of-project-setup-and-workflow-management/documenting-data/", "title": "Principles of Project Setup and Workflow Management", "description": "If your project contains data that has been newly created, you are required to include a documentation of that data in your project."}, {"path": "/tutorials/reproducible-research-and-automation/", "title": "Reproducible Research and Automation", "description": ""}], "building_blocks": [{"path": "/building-blocks/configure-your-computer/automation-and-workflows/make/", "title": "Set up Make", "description": "Learn how to install make on windows, mac, and Linux. Use make to automate the execution of projects, and see how to check if make is installed correctly"}, {"path": "/building-blocks/configure-your-computer/statistics-and-computation/git/", "title": "Set up Git and GitHub", "description": "Git is an open source version control system (VCS) that has gained a lot of traction in the programming community."}, {"path": "/building-blocks/configure-your-computer/statistics-and-computation/python/", "title": "Set up Python", "description": "Python is widely use programming language. Learn how to set it up on your computer."}, {"path": "/building-blocks/configure-your-computer/statistics-and-computation/r/", "title": "Set up R and RStudio", "description": "Learn how to install R and rstudio on your windows, linux or mac. Follow this tutorial on setting up r studio and how to add r to windows path."}, {"path": "/building-blocks/collaborate-and-share-your-work/write-your-paper/amsmath-latex-cheatsheet/", "title": "Cheatsheet for LaTeX Math Commands", "description": "Download our LaTeX math cheat sheet and learn the most important AMS-Math LaTeX commands. View our overview for mathematical expressions, Greek letters and more"}], "categories": {"reproducible": [{"title": "Extract Data From APIs", "path": "/collect-data/extract-data-api", "description": "Learn how to extract data from APIs.", "icon": "fa-solid fa-database"}, {"title": "Avoid Getting Blocked While Scraping", "path": "/collect-data/avoid-getting-blocked", "description": "Take steps to make sure your scraper keeps on running!", "icon": "fa-solid fa-database"}], "learn": [{"title": "Online Data Collection and Management", "path": "/tutorials/open-education/online-data-collection-and-management/odcm-course", "description": "Learn to use web scraping and APIs to collect data for your empirical research project.", "icon": "fa-solid fa-database"}, {"title": "Web Scraping and API Mining", "path": "/tutorials/more-tutorials/web-scraping/web-scraping-tutorial", "description": "Learn to extract data from the web and APIs", "icon": "fa-solid fa-database"}]}}
+{
+    "topics": [
+        {
+            "path": "/topics/computer-setup/software-installation/rstudio/r/",
+            "title": "Set up R and RStudio",
+            "description": "Learn how to install R and rstudio on your windows, linux or mac. Follow this tutorial on setting up r studio and how to add r to windows path."
+        },
+        {
+            "path": "/topics/research-skills/templates-dynamic-content/templates/amsmath-latex-cheatsheet/",
+            "title": "Cheatsheet for LaTeX Math Commands",
+            "description": "Download our LaTeX math cheat sheet and learn the most important AMS-Math LaTeX commands. View our overview for mathematical expressions, Greek letters and more"
+        },
+        {
+            "path": "/topics/automation/automation-tools/makefiles/make/",
+            "title": "Set up Make",
+            "description": "Learn how to install make on windows, mac, and Linux. Use make to automate the execution of projects, and see how to check if make is installed correctly"
+        },
+        {
+            "path": "/topics/computer-setup/software-installation/python/configuring-python-for-webscraping/",
+            "title": "Configuring Python for Web Scraping",
+            "description": "Learn to web scrape using ChromeDriver, Selenium, and Webdriver manager for python. Web scraping using an automated browser by installing ChromeDrive"
+        },
+        {
+            "path": "/topics/automation/ai/gpt-models/chat-gpt-research/",
+            "title": "Use ChatGPT for your research!",
+            "description": "Currently, ChatGPT is everywhere. Learn how to use it efficiently to improve your research."
+        }
+    ],
+    "building_blocks": [
+        {
+            "path": "/topics/automation/ai/transcription/whisper/",
+            "title": "Making transcriptions using OpenAI's Whisper",
+            "description": "Guidance page for using Whisper for translations and transcriptions"
+        },
+        {
+            "path": "/topics/collaborate-share/share-your-work/content-creation/documenting-new-data/",
+            "title": "Document New Data",
+            "description": "If your project contains data that has been newly created, learn how to include a documentation of that data in your project."
+        },
+        {
+            "path": "/topics/collaborate-share/project-management/big-team-science/use-scrum-in-your-team/",
+            "title": "Use Scrum In Your Team",
+            "description": "Discover Scrum to improve your project management when working on empirical research projects"
+        },
+        {
+            "path": "/topics/automation/version-control/advanced-git/git-branching-strategies/",
+            "title": "Git Branching Strategies",
+            "description": "Explore three popular Git branching strategies: Trunk-Based Development, Feature Branching, and Git Flow. Learn their workflow, strengths, weaknesses and suitable projects and teams."
+        },
+        {
+            "path": "topics/automation/ai/gpt-models/github-copilot/",
+            "title": "GitHub Copilot in RStudio",
+            "description": "Learning what GitHub Copilot is, how and why it can be used"
+        }
+    ],
+    "categories": {
+        "reproducible": [
+            {
+                "title": "Extract Data From APIs",
+                "path": "/topics/collect-store/data-collection/apis/extract-data-api",
+                "description": "Learn how to extract data from APIs.",
+                "icon": "fa-solid fa-database"
+            },
+            {
+                "title": "Avoid Getting Blocked While Scraping",
+                "path": "/topics/collect-store/data-collection/web-scraping/avoid-getting-blocked/",
+                "description": "Take steps to make sure your scraper keeps on running!",
+                "icon": "fa-solid fa-database"
+            }
+        ],
+        "learn": [
+            {
+                "title": "Online Data Collection and Management",
+                "path": "/topics/collect-store/data-collection/databases/online-data-collection-management/",
+                "description": "Learn to use web scraping and APIs to collect data for your empirical research project.",
+                "icon": "fa-solid fa-database"
+            },
+            {
+                "title": "Web Scraping and API Mining",
+                "path": "/topics/collect-store/data-collection/web-scraping/web-scraping-tutorial/",
+                "description": "Learn to extract data from the web and APIs",
+                "icon": "fa-solid fa-database"
+            }
+        ]
+    }
+}

--- a/static/json/pages.json
+++ b/static/json/pages.json
@@ -1,1 +1,12 @@
-[{"path": "/tutorials/more-tutorials/chatgpt-article/chat-gpt-research/", "title": "Use ChatGPT for your research!"}, {"path": "/building-blocks/configure-your-computer/automation-and-workflows/make/", "title": "Set up Make"}, {"path": "/building-blocks/configure-your-computer/statistics-and-computation/git/", "title": "Set up Git and GitHub"}, {"path": "/building-blocks/configure-your-computer/statistics-and-computation/python/", "title": "Set up Python"}, {"path": "/building-blocks/configure-your-computer/statistics-and-computation/r/", "title": "Set up R and RStudio"}, {"path": "/tutorials/reproducible-research-and-automation/principles-of-project-setup-and-workflow-management/project-setup-overview/", "title": "Principles of Project Setup and Workflow Management"}, {"path": "/about/", "title": "About"}, {"path": "/building-blocks/", "title": "Building Blocks"}, {"path": "/building-blocks/collaborate-and-share-your-work/write-your-paper/amsmath-latex-cheatsheet/", "title": "Cheatsheet for LaTeX Math Commands"}, {"path": "/tutorials/", "title": "Tutorials"}]
+[
+    {"path": "/topics/Automation/AI/Gpt-models/chat-gpt-research/", "title": "Use ChatGPT for your research!"},
+    {"path": "/topics/automation/automation-tools/makefiles/make/", "title": "Set up Make"},
+    {"path": "/topics/Automation/version-control/start-git/git/", "title": "Set up Git and GitHub"},
+    {"path": "/topics/Computer-Setup/software-installation/Python/python/", "title": "Set up Python"},
+    {"path": "/topics/Computer-Setup/software-installation/RStudio/r/", "title": "Set up R and RStudio"},
+    {"path": "/topics/Manage-manipulate/Loading/getting-started/data-preparation-workflow-management/", "title": "Data Preparation and Workflow Management"},
+    {"path": "/about/", "title": "About"},
+    {"path": "/building-blocks/", "title": "Building Blocks"},
+    {"path": "/topics/Research-skills/templates-dynamic-content/templates/amsmath-latex-cheatsheet/", "title": "Cheatsheet for LaTeX Math Commands"},
+    {"path": "/topics/", "title": "Topics"}
+]

--- a/static/scripts/main.py
+++ b/static/scripts/main.py
@@ -276,7 +276,7 @@ def create_popular_cards_json(input_categories):
 
     # Create Dictionary
     data_dict = {
-        "tutorials": tutorials,
+        "topics": tutorials,
         "building_blocks": building_blocks,
         "categories": categories_output
     }

--- a/static/scripts/main.py
+++ b/static/scripts/main.py
@@ -76,7 +76,7 @@ def fetch_og_description(page_path):
 
 # Collect Top 5 From BB or Tutorials
 # response: result from get_report()
-# path_prefix: "building_blocks" or "tutorials"
+# path_prefix: "building_blocks" or "topics"
 
 
 def fetch_cards_popular_pages(response, path_prefix):
@@ -271,7 +271,7 @@ def create_popular_cards_json(input_categories):
 
     # Get Analytics, Populate popular tutorials and building blocks
     response = get_report()
-    tutorials = fetch_cards_popular_pages(response, "/tutorials/")
+    tutorials = fetch_cards_popular_pages(response, "/topics/")
     building_blocks = fetch_cards_popular_pages(response, "/building-blocks/")
 
     # Create Dictionary


### PR DESCRIPTION
I was looking at issue #7 . I believe that issue has something to do with links not working properly when in the cards on the home page. 
After exploring and analyzing the project structure I noticed that there is some misuse between `tutorials` and `topics`. As far as I can see on the current hugo website which is currently live and in this repository there is no section called `tutorials`. Some of the links were not working because of that (please see the links in `cards.json`  for example). Therefore, wherever I saw in the code `tutorial(s)`  I renamed it to `topic(s)`. 
I tested that clicking in the links at home page works with renamed words.

On top of that I restructured `cards.json` and `pages.json`. Previous versions were not readable.

`Closes #7`

Please let me know @thierrylahaije  if my reasoning is correct or maybe I missed something.
 