### PR TITLE
Exclude Urchin Tracking Module (UTM) from breadcrumps

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -193,7 +193,10 @@ def get_breadcrumbs():
             "name": url_parts[i].replace("-", " ").title(),
             "url": f"{base_url}/{'/'.join(url_parts[:i + 1])}/"  # Gebruik f-string voor duidelijkheid
         }
-        breadcrumbs.append(breadcrumb)
+        if("?utm_" in url_parts[i]):
+            continue
+        else:
+            breadcrumbs.append(breadcrumb)
 
     return breadcrumbs
 


### PR DESCRIPTION
Hannes found an issue with breadcrumps #61 . 
The issue occurred because the whole URL was broken down. Added extra check now to exclude the Urchin Tracking Module (UTM).
 